### PR TITLE
Fix implicit declaration of safe_print_string

### DIFF
--- a/src/libscream.c
+++ b/src/libscream.c
@@ -44,6 +44,7 @@
 
 #include "config.h"
 #include "feature.h"
+#include "misc.h"
 
 /* use libast if we have it */
 #ifdef DEBUG_ESCREEN


### PR DESCRIPTION
This PR fixes this build failure:

```
libscream.c:3231:16: error: implicit declaration of function 'safe_print_string' [-Werror,-Wimplicit-function-declaration]
               safe_print_string(p, width)));
               ^
3 warnings and 1 error generated.
```