### PR TITLE
Add missing include file to src/libscream.c

### DIFF
--- a/src/libscream.c
+++ b/src/libscream.c
@@ -44,6 +44,7 @@
 
 #include "config.h"
 #include "feature.h"
+#include "misc.h"
 
 /* use libast if we have it */
 #ifdef DEBUG_ESCREEN


### PR DESCRIPTION
The safe_print_string function is declared in "misc.h".  This avoids relying on an implicit function declaration, a C feature not necessarily present in C99 and later compilers.